### PR TITLE
Fix libcrypto static linking on recent systems

### DIFF
--- a/obfuscated_bash.c
+++ b/obfuscated_bash.c
@@ -244,7 +244,7 @@ int main(int argc, char *argv[])
   if(flag_status('s',optionarray,sizeof(optionarray)/sizeof(option)))
   { printf("as static binary ");
 //    sprintf(str,"sleep 1 ; sync ;cc %s.c -o %s -static -lssl -lcrypto -ldl -lltdl -static-libgcc && strip %s",input_filename,output_filename,output_filename);
-    sprintf(str,"sleep 1 ; sync ;cc %s.c -o %s -static -lssl -lcrypto -ldl -static-libgcc && strip %s",input_filename,output_filename,output_filename);
+    sprintf(str,"sleep 1 ; sync ;cc %s.c -o %s -static -lssl -lcrypto -ldl -Wl,--whole-archive -lpthread -Wl,--no-whole-archive -static-libgcc && strip %s",input_filename,output_filename,output_filename);
   } else sprintf(str,"sleep 1 ; sync ;cc %s.c -o %s -lssl -lcrypto && strip %s",input_filename,output_filename,output_filename);
 //  printf("%s\n",str); 
 //  exit(0);


### PR DESCRIPTION
On my Debian buster (testing) system with libssl version 1.1.0h, static linking is broken, since apparently libcrypto needs some pthread symbols:

> Output filename will be: prova.sh.x
Random uuid: 564728c7-ddd6-7cd8-6aed-1cd27d0f0995
Random serial: fdc26893669d2768
Used key: >564728c7ddd67cd86aed1cd27d0f0995<
Used IV: >fdc26893669d2768<
input filename: prova.sh
input file size: 40
ciphertext size: 48
base64 encoded ciphertext: 64 : 0 whole lines
intermediate c generated filename: prova.sh.c
Creating reusable intermadiate c file
Created prova.sh.c
/usr/lib/gcc/i686-linux-gnu/7/../../../i386-linux-gnu/libcrypto.a(dso_dlfcn.o): In function `dlfcn_globallookup':
(.text+0x16): warning: Using 'dlopen' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/usr/lib/gcc/i686-linux-gnu/7/../../../i386-linux-gnu/libcrypto.a(b_addr.o): In function `BIO_lookup':
(.text+0xd68): warning: Using 'getaddrinfo' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/usr/lib/gcc/i686-linux-gnu/7/../../../i386-linux-gnu/libcrypto.a(b_sock.o): In function `BIO_gethostbyname':
(.text+0x94): warning: Using 'gethostbyname' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/usr/lib/gcc/i686-linux-gnu/7/../../../i386-linux-gnu/libcrypto.a(threads_pthread.o): In function `CRYPTO_THREAD_lock_new':
(.text+0x31): undefined reference to `pthread_rwlock_init'
/usr/lib/gcc/i686-linux-gnu/7/../../../i386-linux-gnu/libcrypto.a(threads_pthread.o): In function `CRYPTO_THREAD_read_lock':
(.text+0x74): undefined reference to `pthread_rwlock_rdlock'
/usr/lib/gcc/i686-linux-gnu/7/../../../i386-linux-gnu/libcrypto.a(threads_pthread.o): In function `CRYPTO_THREAD_write_lock':
(.text+0xa4): undefined reference to `pthread_rwlock_wrlock'
/usr/lib/gcc/i686-linux-gnu/7/../../../i386-linux-gnu/libcrypto.a(threads_pthread.o): In function `CRYPTO_THREAD_unlock':
(.text+0xd4): undefined reference to `pthread_rwlock_unlock'
/usr/lib/gcc/i686-linux-gnu/7/../../../i386-linux-gnu/libcrypto.a(threads_pthread.o): In function `CRYPTO_THREAD_lock_free':
(.text+0x10d): undefined reference to `pthread_rwlock_destroy'
/usr/lib/gcc/i686-linux-gnu/7/../../../i386-linux-gnu/libcrypto.a(threads_pthread.o): In function `CRYPTO_THREAD_run_once':
(.text+0x148): undefined reference to `pthread_once'
/usr/lib/gcc/i686-linux-gnu/7/../../../i386-linux-gnu/libcrypto.a(threads_pthread.o): In function `CRYPTO_THREAD_init_local':
(.text+0x178): undefined reference to `pthread_key_create'
/usr/lib/gcc/i686-linux-gnu/7/../../../i386-linux-gnu/libcrypto.a(threads_pthread.o): In function `CRYPTO_THREAD_get_local':
(.text+0x1a6): undefined reference to `pthread_getspecific'
/usr/lib/gcc/i686-linux-gnu/7/../../../i386-linux-gnu/libcrypto.a(threads_pthread.o): In function `CRYPTO_THREAD_set_local':
(.text+0x1ca): undefined reference to `pthread_setspecific'
/usr/lib/gcc/i686-linux-gnu/7/../../../i386-linux-gnu/libcrypto.a(threads_pthread.o): In function `CRYPTO_THREAD_cleanup_local':
(.text+0x1f6): undefined reference to `pthread_key_delete'
/usr/lib/gcc/i686-linux-gnu/7/libgcc_eh.a(unwind-dw2.o): In function `uw_init_context_1':
(.text+0x1afa): undefined reference to `pthread_once'
collect2: error: ld returned 1 exit status
Compiling prova.sh.c as static binary ... failed

To fix this I had to link pthread in using the --whole-archive linker directive (simply adding -lpthread doesn't work).

The problem doesn't affect the dynamically linked version which works normally.